### PR TITLE
SongChordTemplate2014.AddChordIds can throw a NullReferenceException

### DIFF
--- a/RocksmithToolkitLib/XML/Song2014.cs
+++ b/RocksmithToolkitLib/XML/Song2014.cs
@@ -476,14 +476,15 @@ namespace RocksmithToolkitLib.Xml {
             for (int i = 0; i < ctemplateList.Count; i++)
             {
                 var ct = ctemplateList[i];
-                var matchingChord = chordTemplates.First(sct =>
+                var matchingChord = chordTemplates.FirstOrDefault(sct =>
                     sct.Fret0 == ct.Frets[0] &&
                     sct.Fret1 == ct.Frets[1] &&
                     sct.Fret2 == ct.Frets[2] &&
                     sct.Fret3 == ct.Frets[3] &&
                     sct.Fret4 == ct.Frets[4] &&
                     sct.Fret5 == ct.Frets[5]);
-                matchingChord.ChordId = ct.ChordId;
+                if (matchingChord != null)
+                    matchingChord.ChordId = ct.ChordId;
             }
             return chordTemplates;
         }


### PR DESCRIPTION
Apparently, in some official arrangements there are chord templates in the manifest that are not contained in the sng. You can easily hit the bug by unpacking (and generating xmls) the songs.psarc. As far as I can tell it's safe to disregard these extra chord templates in the manifest, so I added a check for null in the function.
