### PR TITLE
Fret hand mutes on single notes are not correctly loaded

### DIFF
--- a/RocksmithToolkitLib/XML/Song2014.cs
+++ b/RocksmithToolkitLib/XML/Song2014.cs
@@ -758,6 +758,11 @@ namespace RocksmithToolkitLib.Xml
                 p &= ~Sng2014HSL.Sng2014FileWriter.NOTE_MASK_HARMONIC;
                 this.Harmonic = 1;
             }
+            if ((p & Sng2014HSL.Sng2014FileWriter.NOTE_MASK_MUTE) != 0)
+            {
+                p &= ~Sng2014HSL.Sng2014FileWriter.NOTE_MASK_MUTE;
+                this.Mute = 1;
+            }
             if ((p & Sng2014HSL.Sng2014FileWriter.NOTE_MASK_PALMMUTE) != 0)
             {
                 p &= ~Sng2014HSL.Sng2014FileWriter.NOTE_MASK_PALMMUTE;


### PR DESCRIPTION
This is a simple oversight within Song2014Note.parseNoteMask. This pull request adds the missing code.
