### PR TITLE
Added workaround for official Rancid DLCs

### DIFF
--- a/RocksmithToolkitLib/DLCPackage/Manifest2014/Tone/Tone2014.cs
+++ b/RocksmithToolkitLib/DLCPackage/Manifest2014/Tone/Tone2014.cs
@@ -190,7 +190,11 @@ namespace RocksmithToolkitLib.DLCPackage.Manifest2014.Tone
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            return float.Parse(serializer.Deserialize<string>(reader).Replace(',', '.'), CultureInfo.InvariantCulture);
+            // HACK: Some Rancid DLC manifests contain bogus characters in Volume elements.
+            // Filter only numerical characters
+            string input = new string(serializer.Deserialize<string>(reader).Replace(',', '.')
+                .Where(c => char.IsDigit(c) || c == '.' || c == '-').ToArray());
+            return float.Parse(input, CultureInfo.InvariantCulture);
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)


### PR DESCRIPTION
I stumbled upon this while working on RocksmithToTab. Unpack, for example, the rancfall_p.psarc from the official Rancid DLC pack, and have a look at the manifest json files for either lead or rhythm. You will notice that in the "Tones" section, there are some illegal Volume elements, e.g.:

"Volume": "-20.000Qaqaq",

I do not know where those garbage characters come from, perhaps it's simply an error in the psarc. However, if you try to parse this manifest, it will throw an exception in Tone2014.cs:193 due to these illegal characters.

I added a quick and dirty hack that will filter the input string and only leave numeric characters so that the conversion produces the expected result. That solves my problem, however, it might not be the best way to deal with this situation.